### PR TITLE
scripts: use config file to set AUTHOR

### DIFF
--- a/dist-git.spec
+++ b/dist-git.spec
@@ -30,6 +30,7 @@ Requires:       python-requests
 Requires:       mod_ssl
 Requires:       fedmsg
 Requires:       cronie
+Requires:       crudini
 Requires(pre):  shadow-utils
 
 %description

--- a/scripts/dist-git/git_branch.sh
+++ b/scripts/dist-git/git_branch.sh
@@ -97,7 +97,7 @@ if [ -z "$BRANCH" -o -z "$PACKAGES" ] ; then
 fi
 
 if [ -z $AUTHOR ]; then
-    AUTHOR="Fedora Release Engineering <rel-eng@lists.fedoraproject.org>"
+    AUTHOR=`crudini --get /etc/dist-git/dist-git.conf git default_branch_author`
 fi
 
 

--- a/scripts/dist-git/git_package.sh
+++ b/scripts/dist-git/git_package.sh
@@ -82,7 +82,7 @@ if [ -z $PKG_OWNER_EMAILS ]; then
 fi
 
 if [ -z $AUTHOR ]; then
-    AUTHOR="Fedora Release Engineering <rel-eng@lists.fedoraproject.org>"
+    AUTHOR=`crudini --get /etc/dist-git/dist-git.conf git default_branch_author`
 fi
 
 # Sanity checks before we start doing damage


### PR DESCRIPTION
The copr-dist-git package uses those scripts directly, without
explicitly setting $AUTHOR variable.