### PR TITLE
translate '/' to '-' in package name for mailinglist hook

### DIFF
--- a/scripts/dist-git/setup_git_package
+++ b/scripts/dist-git/setup_git_package
@@ -81,7 +81,7 @@ mkdir -p $REPODIR/$PACKAGE.git
 pushd $REPODIR/$PACKAGE.git >/dev/null
 git init -q --shared --bare
 echo "$PACKAGE" > description # This is used to figure out who to send mail to.
-git config --add hooks.mailinglist "$PACKAGE-owner@fedoraproject.org,scm-commits@lists.fedoraproject.org"
+git config --add hooks.mailinglist "$(echo $PACKAGE | tr '/' '-')-owner@fedoraproject.org,scm-commits@lists.fedoraproject.org"
 git config --add hooks.maildomain fedoraproject.org
 popd >/dev/null
 


### PR DESCRIPTION
This PR is to fix mailinglist hooks for packages with '/' in name.  For example, docker/cockpit.  See infrastructure issue here - https://pagure.io/fedora-infrastructure/issue/5989