### PR TITLE
Use REMOTE_USER as fallback for GSS_NAME

### DIFF
--- a/scripts/httpd/upload.cgi
+++ b/scripts/httpd/upload.cgi
@@ -109,7 +109,7 @@ def main():
     os.umask(002)
 
     username = os.environ.get('SSL_CLIENT_S_DN_CN', None)
-    gssname = os.environ.get('GSS_NAME', None)
+    gssname = os.environ.get('GSS_NAME', os.environ.get('REMOTE_USER', None))
     if gssname and '@' in gssname and not username:
         username = gssname.partition('@')[0]
     if not config.getboolean('upload', 'disable_group_check', fallback=False) and\


### PR DESCRIPTION
GSS_NAME is only set in a specific configuration (with GssapiLocalNames on).
Make the upload.cgi also work if that configuration is not set.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>