### PR TITLE
add script for removing unused source tarballs in lookaside cache

### DIFF
--- a/dist-git.spec
+++ b/dist-git.spec
@@ -138,6 +138,7 @@ install -d %{buildroot}%{_bindir}
 ln -s %{_datadir}/dist-git/setup_git_package %{buildroot}%{_bindir}/setup_git_package
 ln -s %{_datadir}/dist-git/mkbranch %{buildroot}%{_bindir}/mkbranch
 ln -s %{_datadir}/dist-git/mkbranch_branching %{buildroot}%{_bindir}/mkbranch_branching
+ln -s %{_datadir}/dist-git/remove_unused_sources %{buildroot}%{_bindir}/remove_unused_sources
 
 # ------------------------------------------------------------------------------
 # SELinux

--- a/scripts/dist-git/remove_unused_sources
+++ b/scripts/dist-git/remove_unused_sources
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+Usage() {
+    cat <<EOF
+Usage:
+    $0 <package_git_directory> <package_lookaside_directory>
+
+    Removes all tarballs in <package_lookaside_directory> except
+    for tarballs that are referenced by the latest commit of each
+    branch in <package_git_directory>.
+EOF
+}
+
+die() { echo "$*" 1>&2 ; exit 1; }
+
+if [[ $# != 2 ]]; then
+    Usage
+    exit 1
+fi
+
+pkg_git_dir="$1"
+pkg_lookaside_dir="$2"
+
+if [ ! -d "$pkg_git_dir" ]; then
+    echo "$pkg_git_dir is not a valid directory."
+    exit 1
+fi
+if [ ! -d "$pkg_lookaside_dir" ]; then
+    echo "$pkg_lookaside_dir is not a valid directory."
+    exit 1
+fi
+
+pushd "$pkg_git_dir" > /dev/null || exit 1
+
+whitelist=()
+
+# find sources that are referenced by the latest commit in any of the branches
+for branch in $(git for-each-ref --format="%(refname:short)" refs/heads); do
+    while read -r line; do
+        set -- $line
+        hash=$1
+        filename=$2
+        # skip projects using the new format
+        test $# -eq 0 && continue
+        test $# -ne 2 && die "Unsupported format. Only the old '<SUM> <FILENAME' format is used."
+        whitelist+=("$hash","$filename")
+    done < <(git show "$branch":sources)
+done
+
+# remove all source files that are not referenced
+while read -r file; do
+    old_IFS=$IFS
+    IFS=/
+    set -- $file
+    IFS=$old_IFS
+
+    # safety measure, if this is really the layout we expect the first and
+    # third part matches
+    test "$1" = "$3" || continue
+
+    filename=$1
+    hash=$2
+
+    keep=false
+    for source in "${whitelist[@]}"; do
+        IFS=','
+        set -- $source
+        IFS=$old_IFS
+        # keep sources where tarname and hash match the referenced ones
+        if test "$1" = "$hash" -a "$2" = "$filename"; then
+            keep=true
+            break
+        fi
+    done
+
+    "$keep" && continue
+    unlink "$pkg_lookaside_dir/$file"
+done < <( cd "$pkg_lookaside_dir" || exit 1 ; find . -mindepth 3 -maxdepth 3 -type f  -printf '%P\n' )


### PR DESCRIPTION
The script goes through all branches for each project in lookaside cache and keeps directories mentioned in `sources` file, deleting all others.