### PR TITLE
Install an importable python package with helper functions

### DIFF
--- a/dist-git.spec
+++ b/dist-git.spec
@@ -18,6 +18,7 @@ Source0:        %{name}-%{version}.tar.gz
 BuildArch:      noarch
 
 BuildRequires:  systemd
+BuildRequires:  python3-devel
 
 Requires:       httpd
 Requires:       perl(Sys::Syslog)
@@ -115,6 +116,12 @@ cp -a configs/httpd/dist-git/* %{buildroot}%{_sysconfdir}/httpd/conf.d/dist-git/
 cp -a configs/systemd/*        %{buildroot}%{_unitdir}/
 
 # ------------------------------------------------------------------------------
+# python package
+# ------------------------------------------------------------------------------
+mkdir -p %{buildroot}%{python3_sitelib}
+cp -ar distgit %{buildroot}%{python3_sitelib}
+
+# ------------------------------------------------------------------------------
 # /var/lib/ ...... dynamic persistent files
 # ------------------------------------------------------------------------------
 install -d %{buildroot}%{installdir}
@@ -199,6 +206,11 @@ fi
 
 %{_unitdir}/dist-git@.service
 %{_unitdir}/dist-git.socket
+
+# ------------------------------------------------------------------------------
+# python package
+# ------------------------------------------------------------------------------
+%{python3_sitelib}/distgit
 
 # ------------------------------------------------------------------------------
 # /var/lib/ ...... dynamic persistent files

--- a/distgit/upload.py
+++ b/distgit/upload.py
@@ -1,0 +1,103 @@
+import os
+import sys
+import grp
+import errno
+
+
+# Fedora Packager Group
+PACKAGER_GROUP = 'packager'
+
+
+def send_error(text, status='500 Internal Server Error'):
+    """Send an error back to the client
+
+    This ensures that the client will get a proper error, including the HTTP
+    status code, so that it can handle problems appropriately.
+
+    Args:
+        text (str): The error message to send the client
+        status (str, optional): The HTTP status code to return to the client.
+    """
+    print('Status: %s' % status)
+    print('Content-type: text/plain\n')
+    print(text)
+
+    sys.exit(0)
+
+
+def send(text, exit=True):
+    """Send a success message back to the client
+
+    Args:
+        text (str): The message to send the client
+        exit (bool, optional): If we should exit immediatelly or not.
+            Use this if you want to additionally print out more content
+            into response.
+    """
+    print('Status: 200 OK')
+    print('Content-type: text/plain\n')
+    print(text)
+
+    if exit:
+        sys.exit(0)
+
+
+def check_form(form, var):
+    ret = form.getvalue(var, None)
+
+    if ret is None:
+        send_error('Required field "%s" is not present.' % var,
+                   status='400 Bad Request')
+
+    if isinstance(ret, list):
+        send_error('Multiple values given for "%s". Aborting.' % var,
+                   status='400 Bad Request')
+    return ret
+
+
+def check_group(username):
+    authenticated = False
+
+    try:
+        if username in grp.getgrnam(PACKAGER_GROUP)[3]:
+            authenticated = True
+    except KeyError:
+        pass
+
+    return authenticated
+
+
+def hardlink(src, dest, username):
+    makedirs(os.path.dirname(dest), username)
+
+    try:
+        os.link(src, dest)
+    except OSError as e:
+        if e.errno != errno.EEXIST:
+            send_error(str(e))
+
+        # The file already existed at the dest path, hardlink over it
+        os.unlink(dest)
+        os.link(src, dest)
+
+    sys.stderr.write("[username=%s] ln %s %s\n" % (username, src, dest))
+
+
+def makedirs(dir_, username, mode=0o2755):
+    try:
+        os.makedirs(dir_, mode=mode)
+        sys.stderr.write('[username=%s] mkdir %s\n' % (username, dir_))
+    except OSError as e:
+        if e.errno != errno.EEXIST:
+            send_error(str(e))
+
+
+def ensure_namespaced(name, namespace):
+    if not namespace:
+        return name
+
+    name_parts = name.split('/')
+    if len(name_parts) == 1:
+        return os.path.join(namespace, name)
+
+    return name

--- a/scripts/httpd/upload.cgi
+++ b/scripts/httpd/upload.cgi
@@ -7,8 +7,6 @@
 # License: GPL
 
 import cgi
-import errno
-import grp
 import hashlib
 import os
 import sys
@@ -20,106 +18,12 @@ import fedmsg.config
 
 from configparser import ConfigParser
 
+from distgit.upload import (PACKAGER_GROUP, send_error, send, check_form,
+                            check_group, hardlink, makedirs, ensure_namespaced)
+
+
 # Reading buffer size
 BUFFER_SIZE = 4096
-
-# Fedora Packager Group
-PACKAGER_GROUP = 'packager'
-
-
-def send_error(text, status='500 Internal Server Error'):
-    """Send an error back to the client
-
-    This ensures that the client will get a proper error, including the HTTP
-    status code, so that it can handle problems appropriately.
-
-    Args:
-        text (str): The error message to send the client
-        status (str, optional): The HTTP status code to return to the client.
-    """
-    print('Status: %s' % status)
-    print('Content-type: text/plain\n')
-    print(text)
-
-    sys.exit(0)
-
-
-def send(text, exit=True):
-    """Send a success message back to the client
-
-    Args:
-        text (str): The message to send the client
-        exit (bool, optional): If we should exit immediatelly or not.
-            Use this if you want to additionally print out more content
-            into response.
-    """
-    print('Status: 200 OK')
-    print('Content-type: text/plain\n')
-    print(text)
-
-    if exit:
-        sys.exit(0)
-
-
-def check_form(form, var):
-    ret = form.getvalue(var, None)
-
-    if ret is None:
-        send_error('Required field "%s" is not present.' % var,
-                   status='400 Bad Request')
-
-    if isinstance(ret, list):
-        send_error('Multiple values given for "%s". Aborting.' % var,
-                   status='400 Bad Request')
-    return ret
-
-
-def check_group(username):
-    authenticated = False
-
-    try:
-        if username in grp.getgrnam(PACKAGER_GROUP)[3]:
-            authenticated = True
-    except KeyError:
-        pass
-
-    return authenticated
-
-
-def hardlink(src, dest, username):
-    makedirs(os.path.dirname(dest), username)
-
-    try:
-        os.link(src, dest)
-    except OSError as e:
-        if e.errno != errno.EEXIST:
-            send_error(str(e))
-
-        # The file already existed at the dest path, hardlink over it
-        os.unlink(dest)
-        os.link(src, dest)
-
-    sys.stderr.write("[username=%s] ln %s %s\n" % (username, src, dest))
-
-
-def makedirs(dir_, username, mode=0o2755):
-    try:
-        os.makedirs(dir_, mode=mode)
-        sys.stderr.write('[username=%s] mkdir %s\n' % (username, dir_))
-    except OSError as e:
-        if e.errno != errno.EEXIST:
-            send_error(str(e))
-
-
-def ensure_namespaced(name, namespace):
-    if not namespace:
-        return name
-
-    name_parts = name.split('/')
-    if len(name_parts) == 1:
-        return os.path.join(namespace, name)
-
-    return name
 
 
 def main():


### PR DESCRIPTION
There are two motivations for applying this change.

1. It will allow to write unit tests without messing with `PYTHONPATH`
2. It will allow downstream distgit scripts to import these functions
   and reuse them.

I realize that at this point, the added value is negligible (because
no unit tests were added and no dowstream uses the functions) but
this is the first step towards it. At the same time, I deliberately
wanted the change as small as possible and add improvementes once
they are needed, so I tried to not-refactor the code at all even
though I would really love to.