### PR TITLE
Use fixed port number for our python tests

### DIFF
--- a/dist-git.spec
+++ b/dist-git.spec
@@ -110,11 +110,11 @@ exit 0
 
 
 %check
-#%if 0%{?rhel} && 0%{?rhel} < 8
-#nosetests .
-#%else
-#nosetests-3 .
-#%endif
+%if 0%{?rhel} && 0%{?rhel} < 8
+nosetests .
+%else
+nosetests-3 .
+%endif
 
 
 %install

--- a/tests/test_upload_script.py
+++ b/tests/test_upload_script.py
@@ -74,7 +74,7 @@ class UploadTest(unittest.TestCase):
 
     def setUp(self):
         self.hostname = 'localhost'
-        self.port = random.randrange(59898, 65534)
+        self.port = 8888
         # Create temporary filesystem tree
         self.topdir = tempfile.mkdtemp()
         os.chmod(self.topdir, 0o0777)


### PR DESCRIPTION
Randomly generated port numbers worked just find on developer's
machines but Koji have issues with some of the numbers. Let's not
burn hours trying to figure out which ports work and which doesn't
and just settle on one fixed number. It is more deterministic and
reproducible anyway.