### PR TITLE
Don't depend on dist-git-selinux inside containers

### DIFF
--- a/dist-git.spec
+++ b/dist-git.spec
@@ -21,7 +21,11 @@ BuildRequires:  systemd
 
 Requires:       httpd
 Requires:       perl(Sys::Syslog)
+%if 0%{?fedora} || 0%{?rhel} > 7
+Requires:       (dist-git-selinux if selinux-policy-targeted)
+%else
 Requires:       dist-git-selinux
+%endif
 Requires:       git
 Requires:       git-daemon
 Requires:       mod_ssl


### PR DESCRIPTION
Container environments usually don't have the selinux-policy-targeted
package installed, and SELinux isn't enabled from the "inside"
perspective.

Therefore, let's don't depend on the selinux sub-package as long as
the selinux-policy-targeted package isn't installed.  This
dependency conditional idiom is for quite some time used in
copr-backend.spec (and friends) with the corresponding copr-selinux
package.