### PR TITLE
allow to configure name of the master (main) branch

### DIFF
--- a/configs/dist-git/dist-git.conf
+++ b/configs/dist-git/dist-git.conf
@@ -16,6 +16,9 @@ grok           = True
 
 default_namespace = rpms
 
+# name of the default branch (a.k.a. master or main)
+default_branch = master
+
 [upload]
 fedmsgs    = True
 old_paths  = True

--- a/scripts/dist-git/mkbranch
+++ b/scripts/dist-git/mkbranch
@@ -9,6 +9,7 @@ RUNDIR=$(cd "$(dirname "$0")" && pwd)
 
 eval "$(crudini --format=sh --get /etc/dist-git/dist-git.conf dist-git)"
 REPODIR=$gitroot_dir
+SRC_BRANCH="$default_branch"
 
 # check if a moron is driving me
 if [ ! -d $REPODIR ] ; then
@@ -24,7 +25,6 @@ TEST=
 IGNORE=
 BRANCH=""
 PACKAGES=""
-SRC_BRANCH="master"
 
 Usage() {
     cat <<EOF
@@ -32,7 +32,7 @@ Usage:
     $0 [ -s <src_branch>] <branch> <package_name>...
 
     Creates a new branch <branch> for the list of <package_name>s.
-    The /master suffix on branch names is assumed.
+    The /$SRC_BRANCH suffix on branch names is assumed.
 
 Options:
     -n,--test           Don't do nothing, only test
@@ -62,10 +62,9 @@ while [ -n "$1" ] ; do
         TEST="yes"
         ;;
 
-
     -b | --branch )
         shift
-        BRANCH=$1/master
+        BRANCH=$1/$SRC_BRANCH
         ;;
 
     * )
@@ -146,7 +145,7 @@ for NAME in $PACKAGES ; do
     fi
     [ $VERBOSE -gt 0 ] && echo "Creating $NAME $BRANCH from $NAME ..."
     $(pushd $REPODIR/$NAME.git >/dev/null && \
-    git branch --no-track $BRANCH `git rev-list --max-parents=0 master | head -1` && \
+    git branch --no-track $BRANCH `git rev-list --max-parents=0 "$SRC_BRANCH" | head -1` && \
     popd >/dev/null) || {
     echo "ERROR: Branch $NAME $BRANCH could not be created" >&2
         popd >/dev/null

--- a/scripts/dist-git/mkbranch_branching
+++ b/scripts/dist-git/mkbranch_branching
@@ -9,6 +9,7 @@ RUNDIR=$(cd "$(dirname "$0")" && pwd)
 
 eval "$(crudini --format=sh --get /etc/dist-git/dist-git.conf dist-git)"
 REPODIR=$gitroot_dir
+SRC_BRANCH="$default_branch"
 
 # check if a moron is driving me
 if [ ! -d $REPODIR ] ; then
@@ -24,7 +25,6 @@ TEST=
 IGNORE=
 BRANCH=""
 PACKAGES=""
-SRC_BRANCH="master"
 
 Usage() {
     cat <<EOF
@@ -32,7 +32,7 @@ Usage:
     $0 [ -s <src_branch>] <branch> <package_name>...
 
     Creates a new branch <branch> for the list of <package_name>s.
-    The /master suffix on branch names is assumed.
+    The /$SRC_BRANCH suffix on branch names is assumed.
 
 Options:
     -n,--test           Don't do nothing, only test
@@ -64,7 +64,7 @@ while [ -n "$1" ] ; do
 
     -b | --branch )
         shift
-        BRANCH=$1/master
+        BRANCH=$1/$SRC_BRANCH
         ;;
 
     * )
@@ -145,7 +145,7 @@ for NAME in $PACKAGES ; do
     fi
     [ $VERBOSE -gt 0 ] && echo "Creating $NAME $BRANCH from $NAME ..."
     $(pushd $REPODIR/$NAME.git >/dev/null && \
-    git branch --no-track $BRANCH `git rev-list master | head -1` && \
+    git branch --no-track $BRANCH `git rev-list "$SRC_BRANCH" | head -1` && \
     popd >/dev/null) || {
     echo "ERROR: Branch $NAME $BRANCH could not be created" >&2
         popd >/dev/null

--- a/scripts/dist-git/setup_git_package
+++ b/scripts/dist-git/setup_git_package
@@ -7,6 +7,7 @@ umask 0002
 # Figure out the environment we're running in
 eval "$(crudini --format=sh --get /etc/dist-git/dist-git.conf dist-git)"
 REPODIR=$gitroot_dir
+DEFAULT_MAIN=$default_branch
 : ${git_author_name="Undefined"}
 : ${git_author_email="undefined@example.com"}
 
@@ -62,7 +63,7 @@ fi
 
 # Sanity checks before we start doing damage
 [ $VERBOSE -gt 1 ] && echo "Checking package $PACKAGE..."
-if [ -f $REPODIR/$PACKAGE.git/refs/heads/master ] ; then
+if [ -f $REPODIR/$PACKAGE.git/refs/heads/$DEFAULT_MAIN ] ; then
     echo "ERROR: Package module $PACKAGE already exists!" >&2
     exit 128
 fi
@@ -106,7 +107,7 @@ git config user.email "$git_author_email"
 git add .
 git commit -q -m 'Initial setup of the repo'
 git remote add origin $REPODIR/$PACKAGE.git
-git push -q origin master
+git push -q origin "$DEFAULT_MAIN"
 popd >/dev/null
 
 # Place the gitolite update hook in place since we're not using our own


### PR DESCRIPTION
This is preparation for
https://fedoraproject.org/wiki/Changes/GitRepos-master-to-main

For now, there is no change in the name. It still defaults to master. But can be changed by DevOps admin.