### PR TITLE
specify full path

### DIFF
--- a/scripts/dist-git/dist-git-gc
+++ b/scripts/dist-git/dist-git-gc
@@ -2,8 +2,8 @@
 # Cleanup unnecessary files
 # The default DEPTH is 2 because the directory path is /var/lib/dist-git/git/rpms/<package>
 
-REPODIR=$(crudini --get dist-git.conf dist-git gitroot_dir)
-DEPTH=$(crudini --get dist-git.conf dist-git git_gc_depth)
+REPODIR=$(crudini --get /etc/dist-git/dist-git.conf dist-git gitroot_dir)
+DEPTH=$(crudini --get /etc/dist-git/dist-git.conf dist-git git_gc_depth)
 
 find "$REPODIR" -mindepth "$DEPTH" -maxdepth "$DEPTH" -type d |
   while read -r DIRECTORY; do


### PR DESCRIPTION
otherwise the systemd unit will fails when executed from command line and cwd to /etc/dist-git