### PR TITLE
Depend on python3-legacy-cgi for F41+

### DIFF
--- a/dist-git/dist-git.spec
+++ b/dist-git/dist-git.spec
@@ -60,8 +60,14 @@ BuildRequires:  python3-requests
 
 # this should be Requires but see https://bugzilla.redhat.com/show_bug.cgi?id=1833810
 Recommends: moreutils
-
 %endif
+
+%if 0%{?fedora} && 0%{?fedora} >= 41
+# The `cgi` module was removed from the Python 3.13 standard library
+BuildRequires:  python3-legacy-cgi
+Requires:       python3-legacy-cgi
+%endif
+
 
 %description
 DistGit is a Git repository specifically designed to hold RPM


### PR DESCRIPTION
Fix #64

The Python `cgi` module is deprecated since Python 3.11 and removed from the standard library since Python 3.13. According to PEP 594 https://peps.python.org/pep-0594/#cgi
there is no drop-in replacement for `cgi.FieldStorage`. Since we use it for POST requests, I spent a couple of hours trying to reimplement our code using python3-multipart but I am not getting closer to a working solution.

Let's not pay the technical debt yet and depend `python3-legacy-cgi` for as long as we can.