### PR TITLE
releng: make sure `tito .. --test` bumps Version

### DIFF
--- a/.tito/tito.props
+++ b/.tito/tito.props
@@ -3,3 +3,4 @@ builder = tito.builder.Builder
 tagger = tito.tagger.VersionTagger
 changelog_do_not_remove_cherrypick = 0
 changelog_format = %s
+test_version_suffix = .post1


### PR DESCRIPTION
Inspired by the Tito configuration from fedora-copr/copr.