### PR TITLE
Add sysusers.d config file to allow rpm to create users/groups automatically

### DIFF
--- a/dist-git/configs/sysusers.d/dist-git.conf
+++ b/dist-git/configs/sysusers.d/dist-git.conf
@@ -1,0 +1,1 @@
+g packager -

--- a/dist-git/dist-git.spec
+++ b/dist-git/dist-git.spec
@@ -26,7 +26,9 @@ Requires:       git
 Requires:       git-daemon
 Requires:       mod_ssl
 Requires:       crudini
+%if 0%{?rhel} && 0%{?rhel} < 10
 Requires(pre):  shadow-utils
+%endif
 
 Requires:       python3-requests
 Recommends:     python3-grokmirror
@@ -92,13 +94,14 @@ cd -
 
 
 %pre
+%if 0%{?rhel} && 0%{?rhel} < 10
 # ------------------------------------------------------------------------------
 # Users and Groups
 # ------------------------------------------------------------------------------
 getent group packager > /dev/null || \
     groupadd -r packager
 exit 0
-
+%endif
 
 %check
 %if 0%{?rhel} && 0%{?rhel} <= 8
@@ -130,6 +133,8 @@ mkdir -p   %{buildroot}%{_unitdir}
 cp -a configs/httpd/dist-git.conf %{buildroot}%{_sysconfdir}/httpd/conf.d/
 cp -a configs/httpd/dist-git/* %{buildroot}%{_sysconfdir}/httpd/conf.d/dist-git/
 cp -a configs/systemd/*        %{buildroot}%{_unitdir}/
+
+install -m0644 -D configs/sysusers.d/dist-git.conf %{buildroot}%{_sysusersdir}/dist-git.conf
 
 # ------------------------------------------------------------------------------
 # /var/lib/ ...... dynamic persistent files
@@ -247,6 +252,7 @@ fi
 %{_bindir}/remove_unused_sources
 %{_bindir}/setup_git_package
 
+%{_sysusersdir}/dist-git.conf
 
 %files selinux
 %doc selinux/*


### PR DESCRIPTION
forwarded from downstream dist-git with added if-conditions 

Related: https://github.com/fedora-copr/copr/issues/2789