### PR TITLE
client: better clone url detection and error reporting

### DIFF
--- a/dist-git-client/dist_git_client.py
+++ b/dist-git-client/dist_git_client.py
@@ -207,7 +207,12 @@ def get_distgit_config(config, forked_from=None):
     else:
         hostname = parsed_url.hostname
 
-    prefixes = config["clone_host_map"][hostname]
+    try:
+        prefixes = config["clone_host_map"][hostname]
+    except KeyError as err:
+        raise RuntimeError(f"{hostname} (detected from clone URL) not "
+                           "found in dist-git-client configuration") from err
+
     prefix_found = None
     for prefix in prefixes.keys():
         if not parsed_url.path.startswith(prefix):

--- a/dist-git-client/tests/test_url_parser.py
+++ b/dist-git-client/tests/test_url_parser.py
@@ -1,0 +1,29 @@
+""" test clone url parser """
+
+from dist_git_client import parse_clone_url
+
+
+def _checker(url, hostname, path):
+    parsed = parse_clone_url(url)
+    assert parsed.hostname == hostname
+    assert parsed.path == path
+
+
+def test_parse_clone_urls():
+    """ Basic clone url formats """
+    _checker("git@github.com:example/example-project.git",
+             "github.com", "example/example-project.git")
+    _checker("https://github.com/example/example-project.git",
+             "github.com", "/example/example-project.git")
+    _checker("https://github.com/example/example-project",
+             "github.com", "/example/example-project")
+    _checker("ssh://jdoe@pkgs.fedoraproject.org/rpms/example.git",
+             "pkgs.fedoraproject.org", "/rpms/example.git")
+    _checker("https://copr-dist-git.fedorainfracloud.org/git"
+             "/@abrt/retrace-server-devel/retrace-server.git",
+             "copr-dist-git.fedorainfracloud.org",
+             "/git/@abrt/retrace-server-devel/retrace-server.git")
+    _checker("file:///home/foo.git",
+             "localhost", "/home/foo.git")
+    _checker("/home/foo.git",
+             "localhost", "/home/foo.git")


### PR DESCRIPTION
Previously we failed to find `git@github.com:owner/project.git`, and we got ugly tracebacks.