### PR TITLE
dist-git-client: add configuration for CentOS SIG packages

### DIFF
--- a/dist-git-client/etc/default.ini
+++ b/dist-git-client/etc/default.ini
@@ -84,3 +84,11 @@ path_prefixes = /redhat/centos-stream/rpms
 lookaside_location = https://sources.stream.centos.org
 lookaside_uri_pattern = sources/rpms/{name}/{filename}/{hashtype}/{hash}/{filename}
 cloning_pattern = https://gitlab.com/redhat/centos-stream/rpms/{package}.git
+
+[centos-sig]
+clone_hostnames = gitlab.com
+path_prefixes = /CentOS/
+lookaside_location = https://sources.stream.centos.org
+lookaside_uri_pattern = sources/rpms/{name}/{filename}/{hashtype}/{hash}/{filename}
+cloning_pattern_package_parts = sig_name rpms project_name
+cloning_pattern = https://gitlab.com/CentOS/{package}.git


### PR DESCRIPTION
See https://github.com/fedora-copr/copr/issues/3730

It can be used like this:

    dist-git-client clone Hyperscale/rpms/awscli2 --dist-git centos-sig
    cd awscli2
    dist-git-client sources
    dist-git-client srpm