### PR TITLE
client: fix the link to CentOS SIG lookaside

### DIFF
--- a/dist-git-client/etc/default.ini
+++ b/dist-git-client/etc/default.ini
@@ -88,7 +88,7 @@ cloning_pattern = https://gitlab.com/redhat/centos-stream/rpms/{package}.git
 [centos-sig]
 clone_hostnames = gitlab.com
 path_prefixes = /CentOS/
-lookaside_location = https://sources.stream.centos.org
-lookaside_uri_pattern = sources/rpms/{name}/{filename}/{hashtype}/{hash}/{filename}
+lookaside_location = https://git.centos.org
+lookaside_uri_pattern = sources/{name}/{filename}/{hashtype}/{hash}/{filename}
 cloning_pattern_package_parts = sig_name rpms project_name
 cloning_pattern = https://gitlab.com/CentOS/{package}.git


### PR DESCRIPTION
[centos-sig] is sharing the lookaside with [centos].  Per discussion with Nikola here:
https://matrix.to/#/!rALCnapvdNTxUTuENl:matrix.org/$fU5jS6TuvWGEg7-s90L9k_TwAR0wlHAqYpMZHQ0dAf0?via=fedoraproject.org&via=matrix.org&via=fedora.im