### PR TITLE
Switch to pytest, and avoid using parameterized

### DIFF
--- a/dist-git/dist-git.spec
+++ b/dist-git/dist-git.spec
@@ -34,12 +34,9 @@ Requires:       python3-requests
 Recommends:     python3-grokmirror
 Suggests:       python3-fedmsg
 Suggests:       fedora-messaging
-%if 0%{?rhel} == 8
-BuildRequires:  python3-nose
-%else
+
+BuildRequires:  python3-devel
 BuildRequires:  python3-pytest
-%endif
-BuildRequires:  python3-parameterized
 BuildRequires:  python3-requests
 
 # this should be Requires but see https://bugzilla.redhat.com/show_bug.cgi?id=1833810
@@ -104,15 +101,7 @@ exit 0
 %endif
 
 %check
-%if 0%{?rhel} && 0%{?rhel} <= 8
-%if 0%{?rhel} < 8
-nosetests -v .
-%else
-nosetests-3 -v .
-%endif
-%else
-pytest -vv .
-%endif
+%pytest -vv .
 
 
 %install


### PR DESCRIPTION
Orphaned for: Unmaintained upstream -- Pytest 8.4 compatibility problems See https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/MGVCYVCEMJNPCHGNZYNUZWBXEJUWTZOA/